### PR TITLE
Fix: MountFromMemory dataSize should be size_t, not int

### DIFF
--- a/include/SDL_PhysFS.h
+++ b/include/SDL_PhysFS.h
@@ -44,7 +44,7 @@ SDL_PHYSFS_DEF bool SDL_PhysFS_Init(const char* argv);
 SDL_PHYSFS_DEF bool SDL_PhysFS_InitEx(const char* argv, const char* org, const char* app);
 SDL_PHYSFS_DEF bool SDL_PhysFS_Quit();
 SDL_PHYSFS_DEF bool SDL_PhysFS_Mount(const char* newDir, const char* mountPoint);
-SDL_PHYSFS_DEF bool SDL_PhysFS_MountFromMemory(const unsigned char *fileData, int dataSize, const char* newDir, const char* mountPoint);
+SDL_PHYSFS_DEF bool SDL_PhysFS_MountFromMemory(const unsigned char *fileData, size_t dataSize, const char* newDir, const char* mountPoint);
 SDL_PHYSFS_DEF bool SDL_PhysFS_Unmount(const char* oldDir);
 SDL_PHYSFS_DEF SDL_IOStream* SDL_PhysFS_IOFromFile(const char* filename);
 SDL_PHYSFS_DEF SDL_Surface* SDL_PhysFS_LoadBMP(const char* filename);
@@ -309,8 +309,8 @@ bool SDL_PhysFS_Mount(const char* newDir, const char* mountPoint) {
  *
  * @see SDL_PhysFS_Mount()
  */
-bool SDL_PhysFS_MountFromMemory(const unsigned char *fileData, int dataSize, const char* newDir, const char* mountPoint) {
-    if (dataSize <= 0) {
+bool SDL_PhysFS_MountFromMemory(const unsigned char *fileData, size_t dataSize, const char* newDir, const char* mountPoint) {
+    if (dataSize == 0) {
         SDL_SetError("SDL_PhysFS_MountFromMemory: Cannot mount a data size of 0");
         return false;
     }


### PR DESCRIPTION
Changes `SDL_PhysFS_MountFromMemory` `dataSize` parameter from `int` to `size_t` to avoid sign-conversion warnings and support buffers larger than `INT_MAX`. The guard is updated from `<= 0` to `== 0` to match the unsigned type.

Fixes #12