### PR TITLE
Fix: remove inline from Exists/LoadDirectoryFiles/FreeDirectoryFiles

### DIFF
--- a/include/SDL_PhysFS.h
+++ b/include/SDL_PhysFS.h
@@ -677,7 +677,7 @@ bool SDL_PhysFS_SetWriteDir(const char* path) {
  *
  * @see SDL_PhysFS_FreeDirectoryFiles()
  */
-inline char** SDL_PhysFS_LoadDirectoryFiles(const char *directory) {
+char** SDL_PhysFS_LoadDirectoryFiles(const char *directory) {
     return PHYSFS_enumerateFiles(directory);
 }
 
@@ -686,7 +686,7 @@ inline char** SDL_PhysFS_LoadDirectoryFiles(const char *directory) {
  *
  * @see SDL_PhysFS_LoadDirectoryFiles()
  */
-inline void SDL_PhysFS_FreeDirectoryFiles(char** files) {
+void SDL_PhysFS_FreeDirectoryFiles(char** files) {
     PHYSFS_freeList(files);
 }
 
@@ -695,7 +695,7 @@ inline void SDL_PhysFS_FreeDirectoryFiles(char** files) {
  *
  * @return true if it exists, false otherwise.
  */
-inline bool SDL_PhysFS_Exists(const char* file) {
+bool SDL_PhysFS_Exists(const char* file) {
     return PHYSFS_exists(file) != 0;
 }
 


### PR DESCRIPTION
Removes the `inline` keyword from `SDL_PhysFS_Exists`, `SDL_PhysFS_LoadDirectoryFiles`, and `SDL_PhysFS_FreeDirectoryFiles`.

Fixes #11