### PR TITLE
Fix: SDL_PhysFS_LoadFile handles empty files correctly

### DIFF
--- a/include/SDL_PhysFS.h
+++ b/include/SDL_PhysFS.h
@@ -587,8 +587,7 @@ void* SDL_PhysFS_LoadFile(const char* filename, size_t *datasize) {
         return NULL;
     }
 
-    // Empty file: return a 1-byte null-terminated buffer so callers get a
-    // non-NULL pointer and can distinguish "empty" from "error".
+    // Existing empty files get an empty null-terminated buffer.
     if (size == 0) {
         PHYSFS_close(handle);
         void* empty = SDL_malloc(1);

--- a/include/SDL_PhysFS.h
+++ b/include/SDL_PhysFS.h
@@ -578,12 +578,25 @@ void* SDL_PhysFS_LoadFile(const char* filename, size_t *datasize) {
 
     // Check to see how large the file is.
     PHYSFS_sint64 size = PHYSFS_fileLength(handle);
-    if (size <= 0) {
+    if (size < 0) {
+        SDL_PhysFS_SetError("Cannot determine file size");
         if (datasize != NULL) {
             *datasize = 0;
         }
         PHYSFS_close(handle);
         return NULL;
+    }
+
+    // Empty file: return a 1-byte null-terminated buffer so callers get a
+    // non-NULL pointer and can distinguish "empty" from "error".
+    if (size == 0) {
+        PHYSFS_close(handle);
+        void* empty = SDL_malloc(1);
+        ((char*)empty)[0] = '\0';
+        if (datasize != NULL) {
+            *datasize = 0;
+        }
+        return empty;
     }
 
     // Read the file, with an extra byte for null termination.


### PR DESCRIPTION
Splits the `size <= 0` guard into two cases:
- `size < 0`: `PHYSFS_fileLength` failed — set an SDL error and return NULL.
- `size == 0`: legitimately empty file — return a non-NULL 1-byte null-terminated buffer with `*datasize == 0` and no SDL error set.

This lets callers distinguish a missing/unreadable file from an empty one using the standard SDL error pattern.

Fixes #10