### PR TITLE
Update SDL_PhysFS_Mix_LoadMUS to SDL_PhysFS_MIX_LoadAudio

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ SDL_IOStatus SDL_PhysFS_IOStatus(int error);
 
 // Optional Integrations
 SDL_Surface* SDL_PhysFS_IMG_Load(const char* filename);    // SDL_image
-Mix_Music* SDL_PhysFS_Mix_LoadMUS(const char* filename);   // SDL_mixer
+Mix_Music* SDL_PhysFS_MIX_LoadAudio(const char* filename); // SDL_mixer
 TTF_Font* SDL_PhysFS_TTF_OpenFont(const char* filename, int ptsize); // SDL_ttf
 SDL_Surface* SDL_PhysFS_STBIMG_Load(const char* filename); // SDL_stbimage.h
 ```

--- a/include/SDL_PhysFS.h
+++ b/include/SDL_PhysFS.h
@@ -88,7 +88,7 @@ SDL_PHYSFS_DEF SDL_IOStream *SDL_PhysFS_OpenIO(PHYSFS_File *handle);
 #define SDL_PhysFS_STBIMG_Load(filename) (STBIMG_Load_RW(SDL_PhysFS_IOFromFile(filename), 1))
 #endif  // SDL_PhysFS_STBIMG_Load
 
-#ifndef SDL_PhysFS_Mix_LoadMUS
+#ifndef SDL_PhysFS_MIX_LoadAudio
 /**
  * Load a supported audio format with SDL_mixer into a music object through PhysFS.
  *
@@ -98,8 +98,8 @@ SDL_PHYSFS_DEF SDL_IOStream *SDL_PhysFS_OpenIO(PHYSFS_File *handle);
  *
  * @see https://github.com/libsdl-org/SDL_mixer
  */
-#define SDL_PhysFS_Mix_LoadMUS(filename) (Mix_LoadMUS_IO(SDL_PhysFS_IOFromFile(filename), 1))
-#endif  // SDL_PhysFS_Mix_LoadMUS
+#define SDL_PhysFS_MIX_LoadAudio(filename) (Mix_LoadAudio_IO(SDL_PhysFS_IOFromFile(filename), 1))
+#endif  // SDL_PhysFS_MIX_LoadAudio
 
 #ifndef SDL_PhysFS_TTF_OpenFont
 /**


### PR DESCRIPTION
Rename `SDL_PhysFS_Mix_LoadMUS` to `SDL_PhysFS_MIX_LoadAudio` and update the underlying call to `Mix_LoadAudio_IO`. Fixes #26