### PR TITLE
Add LoadJPG, LoadPNG, and LoadSurface

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ bool SDL_PhysFS_MountFromMemory(const unsigned char *fileData, int dataSize, con
 bool SDL_PhysFS_Unmount(const char* oldDir);
 SDL_IOStream* SDL_PhysFS_IOFromFile(const char* filename);
 SDL_Surface* SDL_PhysFS_LoadBMP(const char* filename);
+SDL_Surface* SDL_PhysFS_LoadJPG(const char* filename);
+SDL_Surface* SDL_PhysFS_LoadPNG(const char* filename);
+SDL_Surface* SDL_PhysFS_LoadSurface(const char* filename);
 bool SDL_PhysFS_LoadWAV(const char* filename, SDL_AudioSpec* spec, Uint8** audio_buf, Uint32* audio_len);
 void* SDL_PhysFS_LoadFile(const char* filename, size_t* datasize);
 size_t SDL_PhysFS_WriteFile(const char* file, const void* buffer, size_t size);

--- a/include/SDL_PhysFS.h
+++ b/include/SDL_PhysFS.h
@@ -48,6 +48,9 @@ SDL_PHYSFS_DEF bool SDL_PhysFS_MountFromMemory(const unsigned char *fileData, si
 SDL_PHYSFS_DEF bool SDL_PhysFS_Unmount(const char* oldDir);
 SDL_PHYSFS_DEF SDL_IOStream* SDL_PhysFS_IOFromFile(const char* filename);
 SDL_PHYSFS_DEF SDL_Surface* SDL_PhysFS_LoadBMP(const char* filename);
+SDL_PHYSFS_DEF SDL_Surface* SDL_PhysFS_LoadJPG(const char* filename);
+SDL_PHYSFS_DEF SDL_Surface* SDL_PhysFS_LoadPNG(const char* filename);
+SDL_PHYSFS_DEF SDL_Surface* SDL_PhysFS_LoadSurface(const char* filename);
 SDL_PHYSFS_DEF bool SDL_PhysFS_LoadWAV(const char* filename, SDL_AudioSpec * spec, Uint8 ** audio_buf, Uint32 * audio_len);
 SDL_PHYSFS_DEF void* SDL_PhysFS_LoadFile(const char* filename, size_t *datasize);
 SDL_PHYSFS_DEF size_t SDL_PhysFS_WriteFile(const char* file, const void* buffer, size_t size);
@@ -541,6 +544,54 @@ SDL_Surface* SDL_PhysFS_LoadBMP(const char* filename) {
     }
 
     return SDL_LoadBMP_IO(io, 1);
+}
+
+/**
+ * Loads a JPG file from PhysFS.
+ *
+ * @param filename The filename of the JPG file to load.
+ *
+ * @return The SDL_Surface, or NULL on failure, use SDL_GetError() for details.
+ */
+SDL_Surface* SDL_PhysFS_LoadJPG(const char* filename) {
+    SDL_IOStream* io = SDL_PhysFS_IOFromFile(filename);
+    if (io == NULL) {
+        return NULL;
+    }
+
+    return SDL_LoadJPG_IO(io, 1);
+}
+
+/**
+ * Loads a PNG file from PhysFS.
+ *
+ * @param filename The filename of the PNG file to load.
+ *
+ * @return The SDL_Surface, or NULL on failure, use SDL_GetError() for details.
+ */
+SDL_Surface* SDL_PhysFS_LoadPNG(const char* filename) {
+    SDL_IOStream* io = SDL_PhysFS_IOFromFile(filename);
+    if (io == NULL) {
+        return NULL;
+    }
+
+    return SDL_LoadPNG_IO(io, 1);
+}
+
+/**
+ * Loads a surface from any supported image format through PhysFS.
+ *
+ * @param filename The filename of the image file to load.
+ *
+ * @return The SDL_Surface, or NULL on failure, use SDL_GetError() for details.
+ */
+SDL_Surface* SDL_PhysFS_LoadSurface(const char* filename) {
+    SDL_IOStream* io = SDL_PhysFS_IOFromFile(filename);
+    if (io == NULL) {
+        return NULL;
+    }
+
+    return SDL_LoadSurface_IO(io, NULL, 1);
 }
 
 /**


### PR DESCRIPTION
Add `SDL_PhysFS_LoadJPG`, `SDL_PhysFS_LoadPNG`, and `SDL_PhysFS_LoadSurface` following the same pattern as `SDL_PhysFS_LoadBMP`. Fixes #25