### PR TITLE
Add SDL_PhysFS_LoadSVG() macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ bool SDL_PhysFS_Exists(const char* file);
 SDL_IOStatus SDL_PhysFS_IOStatus(int error);
 int SDL_PhysFS_GetVersion();
 
+SDL_Surface* SDL_PhysFS_LoadSVG(const char* filename);             // SDL 3.6.0+
+
 // Optional Integrations
 SDL_Surface* SDL_PhysFS_IMG_Load(const char* filename);    // SDL_image
 Mix_Music* SDL_PhysFS_MIX_LoadAudio(const char* filename); // SDL_mixer

--- a/README.md
+++ b/README.md
@@ -62,9 +62,8 @@ bool SDL_PhysFS_Exists(const char* file);
 SDL_IOStatus SDL_PhysFS_IOStatus(int error);
 int SDL_PhysFS_GetVersion();
 
-SDL_Surface* SDL_PhysFS_LoadSVG(const char* filename);             // SDL 3.6.0+
-
 // Optional Integrations
+SDL_Surface* SDL_PhysFS_LoadSVG(const char* filename);     // SDL 3.6.0+
 SDL_Surface* SDL_PhysFS_IMG_Load(const char* filename);    // SDL_image
 Mix_Music* SDL_PhysFS_MIX_LoadAudio(const char* filename); // SDL_mixer
 TTF_Font* SDL_PhysFS_TTF_OpenFont(const char* filename, int ptsize); // SDL_ttf

--- a/include/SDL_PhysFS.h
+++ b/include/SDL_PhysFS.h
@@ -127,6 +127,19 @@ SDL_PHYSFS_DEF SDL_IOStream *SDL_PhysFS_OpenIO(PHYSFS_File *handle);
 #define SDL_PhysFS_TTF_OpenFont(filename, ptsize) (TTF_OpenFontIO(SDL_PhysFS_IOFromFile(filename), true, ptsize))
 #endif  // SDL_PhysFS_TTF_OpenFont
 
+#ifndef SDL_PhysFS_LoadSVG
+/**
+ * Load an SVG file from PhysFS into an SDL_Surface.
+ *
+ * Requires SDL 3.6.0 or newer.
+ *
+ * @param filename A const char* representing the file to load from PhysFS.
+ *
+ * @return The SDL_Surface*, or NULL on failure. Use SDL_GetError() to get more information.
+ */
+#define SDL_PhysFS_LoadSVG(filename) (SDL_LoadSVG_IO(SDL_PhysFS_IOFromFile(filename), true))
+#endif  // SDL_PhysFS_LoadSVG
+
 #ifndef SDL_PhysFS_AddGamepadMappings
 /**
  * Load a set of gamepad mappings from PhysFS.


### PR DESCRIPTION
## Summary
- Add `SDL_PhysFS_LoadSVG()` macro wrapping `SDL_LoadSVG_IO()` for SVG surface loading via PhysFS (requires SDL 3.6.0+)